### PR TITLE
Add missing includes

### DIFF
--- a/C3SharpInterface/C3SharpInterface.csproj
+++ b/C3SharpInterface/C3SharpInterface.csproj
@@ -100,6 +100,8 @@
     <Compile Include="Responses\ProxyInformationResponse.cs" />
     <Compile Include="Responses\VariableMultipleResponse.cs" />
     <Compile Include="Responses\VariableValueResponse.cs" />
+    <Compile Include="Responses\VolumeListResponse.cs" />
+    <Compile Include="Responses\VolumePropertiesResponse.cs" />
     <Compile Include="SyncClient.cs" />
     <Compile Include="SyncFileStream.cs" />
   </ItemGroup>


### PR DESCRIPTION
Fixed build error by adding the missing includes for the files "VolumenListResponse.cs" and "VolumePropertiesResponse.cs".